### PR TITLE
Updated setup-java step

### DIFF
--- a/.github/workflows/buildspigot-buildtools.yml
+++ b/.github/workflows/buildspigot-buildtools.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 0 6,12,18,24,30 * *"
 
   workflow_dispatch:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/buildspigot-buildtools.yml
+++ b/.github/workflows/buildspigot-buildtools.yml
@@ -40,7 +40,7 @@ jobs:
         
       - name: "Getting Current Date"
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: "Creating Release"
         uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/buildspigot-buildtools.yml
+++ b/.github/workflows/buildspigot-buildtools.yml
@@ -16,10 +16,13 @@ jobs:
         run: "curl https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -o ./BuildTools.jar"
 
       - name: "Setting up Java Development Kit"
-        uses: "actions/setup-java@v2.1.0"
+        uses: "actions/setup-java@v4"
         with:
-          distribution: "adopt"
-          java-version: "17"
+          # You can get the distribution lists at
+          # https://github.com/actions/setup-java#supported-distributions
+          distribution: "temurin"
+          # Use a proper Java version to execute the build application
+          java-version: "21"
 
       # Build Spigot by BuildTools
       - name: "Building Spigot"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ You can get the other version just doing following steps,
 
 ### 兼容的 Java 版本
 
-- Minecraft 1.18 and above
+- Minecraft 1.21 and above
+  - `java-version: "21"`
+- Minecraft 1.18 until 1.20
   - `java-version: "17"`
 - Minecraft 1.17
   - `java-version: "16"`


### PR DESCRIPTION
now uses "temurin" instead of old "adopt" and updated the version to Java 21 to be compatible with the latest Minecraft version.